### PR TITLE
feat: migrate to assistants v2

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -299,7 +299,7 @@ const doProxy = (req, res) => {
         },
         proxyReqOptDecorator: function (proxyReqOpts, srcReq) {
             proxyReqOpts.headers['authorization'] = `Bearer ${API_KEY}`;
-            proxyReqOpts.headers['OpenAI-Beta'] = 'assistants=v1';
+            proxyReqOpts.headers['OpenAI-Beta'] = 'assistants=v2';
             console.log('proxyReqOpts', proxyReqOpts.headers);
             return proxyReqOpts;
         },
@@ -331,7 +331,7 @@ const doProxy = (req, res) => {
         },
         proxyReqOptDecorator: function (proxyReqOpts, srcReq) {
             proxyReqOpts.headers['authorization'] = `Bearer ${API_KEY}`;
-            proxyReqOpts.headers['OpenAI-Beta'] = 'assistants=v1';
+            proxyReqOpts.headers['OpenAI-Beta'] = 'assistants=v2';
             console.log('proxyReqOpts', proxyReqOpts.headers);
             return proxyReqOpts;
         },


### PR DESCRIPTION
Set appropriate header `OpenAI-Beta: assistants=v2`.